### PR TITLE
Twitter image f param

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "multisearch",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/storyful/multisearch",
   "license": "MIT",
   "private": true,

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Storyful Multisearch",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "manifest_version": 2,
   "homepage_url": "http://www.storyful.com",
   "icons": {

--- a/src/browser_action/browser_action.html
+++ b/src/browser_action/browser_action.html
@@ -45,7 +45,7 @@
 											checked="checked"
 											id="preset_twitter_images"
 											data-service="Twitter Images"
-											data-search-url="https://twitter.com/#!/search?q={{k}}%20AND%20%28pic.twitter.com%20OR%20Lockerz%20OR%20Twitpic%20OR%20Flickr%20OR%20Yfrog%20OR%20say.ly%20OR%20ow.ly%20OR%20twitgoo%20OR%20imageshack%20OR%20photobucket%20OR%20instagram%29%20-RT&src=typd&vertical=default&f=tweets">
+											data-search-url="https://twitter.com/search?f=images&q={{k}}">
 
 							<i class="fa fa-check"></i>
 							<span>Twitter Images</span>


### PR DESCRIPTION
The Twitter search for photos (images) allows it to be set via f=images in the URL now. Also suggest removing the -RT as it no longer applies (native retweets) and remove the various OR operators for image services as the Twitter image search is robust. I tested it on a few examples and the results are the same with or without them.
