### PR TITLE
Twitter video f param

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Storyful Multisearch",
-  "version": "2.1.6",
+  "version": "2.2.1",
   "manifest_version": 2,
   "homepage_url": "http://www.storyful.com",
   "icons": {

--- a/src/browser_action/browser_action.html
+++ b/src/browser_action/browser_action.html
@@ -57,7 +57,7 @@
 											checked="checked"
 											id="preset_twitter_videos"
 											data-service="Twitter Videos"
-											data-search-url="https://twitter.com/#!/search?q={{k}}%20AND%20(twitvid%20OR%20bambuser%20OR%20qik%20OR%20YouTube%20OR%20posterous.com%20OR%20vine.co%20OR%20Vimeo%20OR%20dailymotion)%20-RT&vertical=default&f=tweets">
+											data-search-url="https://twitter.com/search?f=videos&q={{k}}">
 							<i class="fa fa-check"></i>
 							<span>Twitter Videos</span>
 						</label>


### PR DESCRIPTION
The Twitter search for videos allows it to be set via f=videos in the URL now. Also suggest removing the -RT as it no longer applies (native retweets) and remove the various OR operators for videos services as the Twitter videos search is robust. I tested it on a few examples and the results are the same with or without them.
